### PR TITLE
Upgrade to sha256

### DIFF
--- a/obdgpslogger.rb
+++ b/obdgpslogger.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Obdgpslogger < Formula
   homepage 'http://icculus.org/obdgpslogger/'
   url 'http://icculus.org/obdgpslogger/downloads/obdgpslogger-0.16.tar.gz'
-  sha1 'a47c79b3c0570ed831f713ebf8c370c6e64b7a6c'
+  sha256 '7255307b846c19c1ebd7c79bd0d9a5759a6f88917b9a6b01f8e52cc7f98025d2'
 
   depends_on 'cmake' => :build
   depends_on 'gpsd'


### PR DESCRIPTION
When I tried to install via this repo:

```
$ brew tap totakke/obdgpslogger
==> Tapping totakke/obdgpslogger
Cloning into '/usr/local/Homebrew/Library/Taps/totakke/homebrew-obdgpslogger'...
remote: Counting objects: 5, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 5 (delta 0), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (5/5), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/totakke/homebrew-obdgpslogger/obdgpslogger.rb
Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/usr/local/Homebrew/Library/Taps/totakke/homebrew-obdgpslogger/obdgpslogger.rb:6:in `<class:Obdgpslogger>'
Please report this to the totakke/obdgpslogger tap!
Error: Cannot tap totakke/obdgpslogger: invalid syntax in tap!
```

To fix the problem:

* Get the new sha256 checksum
```
$ wget http://icculus.org/obdgpslogger/downloads/obdgpslogger-0.16.tar.gz
$ shasum -a 256 obdgpslogger-0.16.tar.gz
```
* Put this new checksum in `obdgpslogger.rb`

This yielded a working brew formula.